### PR TITLE
Rename API Key variable

### DIFF
--- a/mw-thesaurus.el
+++ b/mw-thesaurus.el
@@ -63,7 +63,7 @@
 (define-key mw-thesaurus-mode-map [remap org-open-at-point] #'mw-thesaurus-lookup-at-point)
 (define-key mw-thesaurus-mode-map (kbd "q") #'mw-thesaurus--quit)
 
-(defcustom mw-thesaurus--api-key
+(defcustom mw-thesaurus-api-key
   "67d977d5-790b-412e-a547-9dbcc2bcd525"
   "Merriam-Webster API access key."
   :type 'string)
@@ -246,7 +246,7 @@ If there is no selection provided, additional input will be required."
   (let* ((word (mw-thesaurus-get-original-word beginning end))
          (url (concat (symbol-value 'mw-thesaurus--base-url)
                       word "?key="
-                      (symbol-value 'mw-thesaurus--api-key))))
+                      (symbol-value 'mw-thesaurus-api-key))))
     (request url
              :parser (lambda () (xml-parse-region (point-min) (point-max)))
              :success (cl-function

--- a/readme.org
+++ b/readme.org
@@ -13,7 +13,7 @@
   - Obtain a key for Merriam-Webster Thesaurus
   - Set the variable
   #+begin_src emacs-lisp
-    (setq mw-thesaurus--api-key "YOUR-API-KEY")
+    (setq mw-thesaurus-api-key "YOUR-API-KEY")
   #+end_src
 
 *** Spacemacs layer


### PR DESCRIPTION
* mw-thesaurus.el (mw-thesaurus--api-key): Rename to mw-thesaurus-api-key
* readme.org: Update Variable in HowTo

This primarily really for my OCD. "--" usually indicates private symbols.
But since this one can/has to be customized, I though a single "-" would be better.